### PR TITLE
[HUST CSE]fix: Fixed the  judgment order of null pointer

### DIFF
--- a/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -378,7 +378,6 @@ static char *find_env(const char *key) {
         return NULL;
     }
     
-
     /* from data section start to data section end */
     env_start = (char *) ((char *) env_cache + ENV_PARAM_PART_BYTE_SIZE);
     env_end = (char *) ((char *) env_cache + ENV_PARAM_PART_BYTE_SIZE + get_env_detail_size());

--- a/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,12 +371,13 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
         return NULL;
     }
+    
 
     /* from data section start to data section end */
     env_start = (char *) ((char *) env_cache + ENV_PARAM_PART_BYTE_SIZE);
@@ -386,7 +387,8 @@ static char *find_env(const char *key) {
     if (env_start == env_end) {
         return NULL;
     }
-
+    
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t  env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */


### PR DESCRIPTION
这些代码在判断key是否是“NULL”之前就调用了strlen(key)。如果key是空指针，则strlen(key)是不合法的。因此我们应当在排除key是空指针的情况之后再调用strlen(key)，即
size_t key_len = strlen(key);
应该放在if ((key == NULL) || (*key == '\0'))条件判断之后。