### PR TITLE
[HUST CSE]fix: Fixed the  judgment order of null pointer

### DIFF
--- a/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/11_component_kv/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/14_component_adbd/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/16_iot_wifi_manager/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/21_iot_mqtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/29_iot_ota_http/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/30_iot_netutils/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/31_iot_cloud_rtt/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/32_iot_cloud_onenet/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/33_iot_cloud_ali_iotkit/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/34_iot_cloud_ms_azure/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/35_iot_cloud_tencent/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env.c
+++ b/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env.c
@@ -356,7 +356,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || *key == '\0') {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -372,6 +372,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */

--- a/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
+++ b/examples/36_iot_board_demo/packages/EasyFlash-v3.3.0/src/ef_env_wl.c
@@ -371,7 +371,7 @@ static EfErrCode write_env(const char *key, const char *value) {
  */
 static char *find_env(const char *key) {
     char *env_start, *env_end, *env, *found_env = NULL;
-    size_t key_len = strlen(key), env_len;
+    size_t env_len;
 
     if ((key == NULL) || (*key == '\0')) {
         EF_INFO("Flash ENV name must be not empty!\n");
@@ -387,6 +387,7 @@ static char *find_env(const char *key) {
         return NULL;
     }
 
+    size_t key_len = strlen(key);
     env = env_start;
     while (env < env_end) {
         /* the key length must be equal */


### PR DESCRIPTION
# **拉取** / ****合并请求描述：**** **(PR description)**

[

**为什么提交这份** PR (why to submit this PR)

这些代码在判断key是否是“NULL”之前就调用了strlen(key)。如果key是空指针，则strlen(key)是不合法的。

**你的解决方案是什么** **(what is your solution)**

应当在排除key是空指针的情况之后再调用strlen(key)，即size_t key_len = strlen(key);应该放在if ((key == NULL) || (*key == '\0'))条件判断之后。

**在什么测试环境下测试通过** **(what is the test environment)**

all
 ]

**当前拉取** / **合并请求的状态**  **Intent for your PR**

必须选择一项 Choose one (Mandatory):
- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

**代码质量**  **Code Quality** ：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含#if 0代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)

