### PR TITLE
[HUST CSE] fix: Fixed the issue of potentially returning a pointer th…

### DIFF
--- a/examples/33_iot_cloud_ali_iotkit/packages/ali-iotkit-v2.0.3/iotkit-embedded/sample/linkkit/src/lite_queue.c
+++ b/examples/33_iot_cloud_ali_iotkit/packages/ali-iotkit-v2.0.3/iotkit-embedded/sample/linkkit/src/lite_queue.c
@@ -41,9 +41,12 @@ err_handler:
         lite_queue->lite_queue_mutex = NULL;
     }
 
-    if (lite_queue) free(lite_queue);
+    if (lite_queue){
+        free(lite_queue);
+        lite_queue = NULL;
+    }
 
-    return lite_queue;
+    return NULL;
 }
 
 void lite_queue_destroy(lite_queue_t* _lite_queue)


### PR DESCRIPTION
问题：源代码在err_handler错误处理块中，会将已经free掉的指针lite_queue返回。
解决：free掉该指针后将其赋值为NULL，并将返回值修改为NULL